### PR TITLE
Adding README.md Unity meta file

### DIFF
--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d7823c18466e51748a247788618456b4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Without this file being in the repository git would complain about the submodule being dirty.   Adding this file clears that complaint.