### PR TITLE
Connection point fix

### DIFF
--- a/Runtime/NodeGroup.cs
+++ b/Runtime/NodeGroup.cs
@@ -19,6 +19,7 @@ namespace XNode.NodeGroups {
 			List<Node> result = new List<Node>();
 			foreach (Node node in graph.nodes) {
 				if (node == this) continue;
+				if (node == null) continue;
 				if (node.position.x < this.position.x) continue;
 				if (node.position.y < this.position.y) continue;
 				if (node.position.x > this.position.x + width) continue;


### PR DESCRIPTION
If you use additional connection points in your graph you will see the NullRefExeption and your group will not be able to capture nodes inside, because of connection point(it's the same node with null type). This small fix add ability to capture graphs with connection points.