### PR TITLE
Added missing meta file.

### DIFF
--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3bf44aaf6e840f58efaafb2eb2a8254
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
License.md had a missing .meta file, which was leading to warnings in editor at startup.